### PR TITLE
remove hard-coded, statically allocated array sizes for tmpT and tmpZ

### DIFF
--- a/vic/drivers/shared_all/src/compute_derived_state_vars.c
+++ b/vic/drivers/shared_all/src/compute_derived_state_vars.c
@@ -46,13 +46,20 @@ compute_derived_state_vars(all_vars_struct *all_vars,
     size_t                     veg;
     size_t                     lidx;
     size_t                     band;
+    size_t                     tmpTshape[] = {
+        MAX_LAYERS, MAX_NODES,
+        MAX_FROST_AREAS + 1
+    };
+    size_t                     tmpZshape[] = {
+        MAX_LAYERS, MAX_NODES
+    };
     int                        ErrorFlag;
     double                     Cv;
     double                     moist[MAX_VEG][MAX_BANDS][MAX_LAYERS];
     double                     dt_thresh;
     double                     tmp_runoff;
-    double                     tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1];
-    double                     tmpZ[MAX_LAYERS][MAX_NODES];
+    double                  ***tmpT;
+    double                   **tmpZ;
 
     cell_data_struct         **cell;
     energy_bal_struct        **energy;
@@ -62,6 +69,10 @@ compute_derived_state_vars(all_vars_struct *all_vars,
     energy = all_vars->energy;
     snow = all_vars->snow;
     Nveg = veg_con[0].vegetat_type_num;
+
+    // allocate memory for tmpT and tmpZ
+    malloc_3d_double(tmpTshape, &tmpT);
+    malloc_2d_double(tmpZshape, &tmpZ);
 
     /******************************************
        Compute derived soil layer vars
@@ -238,4 +249,7 @@ compute_derived_state_vars(all_vars_struct *all_vars,
             }
         }
     }
+    // free memory for tmpT and tmpZ
+    free_3d_double(tmpTshape, tmpT);
+    free_2d_double(tmpZshape, tmpZ);
 }

--- a/vic/drivers/shared_all/src/compute_derived_state_vars.c
+++ b/vic/drivers/shared_all/src/compute_derived_state_vars.c
@@ -46,6 +46,7 @@ compute_derived_state_vars(all_vars_struct *all_vars,
     size_t                     veg;
     size_t                     lidx;
     size_t                     band;
+    // sizes of tmpTshape and tmpZshape are hardcoded for convenience
     size_t                     tmpTshape[] = {
         MAX_LAYERS, MAX_NODES,
         MAX_FROST_AREAS + 1

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -44,6 +44,7 @@ generate_default_state(all_vars_struct *all_vars,
     size_t                   band;
     size_t                   lidx;
     size_t                   k;
+    // sizes of tmpTshape and tmpZshape are hardcoded for convenience
     size_t                   tmpTshape[] = {
         MAX_LAYERS, MAX_NODES,
         MAX_FROST_AREAS + 1

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -44,10 +44,17 @@ generate_default_state(all_vars_struct *all_vars,
     size_t                   band;
     size_t                   lidx;
     size_t                   k;
+    size_t                   tmpTshape[] = {
+        MAX_LAYERS, MAX_NODES,
+        MAX_FROST_AREAS + 1
+    };
+    size_t                   tmpZshape[] = {
+        MAX_LAYERS, MAX_NODES
+    };
     double                   Cv;
     double                   tmp;
-    double                   tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1];
-    double                   tmpZ[MAX_LAYERS][MAX_NODES];
+    double                ***tmpT;
+    double                 **tmpZ;
     int                      ErrorFlag;
 
     cell_data_struct       **cell;
@@ -56,6 +63,10 @@ generate_default_state(all_vars_struct *all_vars,
     cell = all_vars->cell;
     energy = all_vars->energy;
     Nveg = veg_con[0].vegetat_type_num;
+
+    // allocate memory for tmpT and tmpZ
+    malloc_3d_double(tmpTshape, &tmpT);
+    malloc_2d_double(tmpZshape, &tmpZ);
 
     /************************************************************************
        Initialize soil moistures
@@ -174,4 +185,7 @@ generate_default_state(all_vars_struct *all_vars,
             }
         }
     }
+    // free memory for tmpT and tmpZ
+    free_3d_double(tmpTshape, tmpT);
+    free_2d_double(tmpZshape, tmpZ);
 }

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -144,14 +144,14 @@ double ErrorIcePackEnergyBalance(double Tsurf, ...);
 double ErrorPrintIcePackEnergyBalance(double, va_list);
 int ErrorPrintSnowPackEnergyBalance(double, va_list);
 int ErrorSnowPackEnergyBalance(double Tsurf, ...);
-void estimate_frost_temperature_and_depth(double tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1], double tmpZ[MAX_LAYERS][MAX_NODES], double *, double *, double *, double *, double, size_t,
-                                          size_t);
-int estimate_layer_ice_content(layer_data_struct *,
-                               double tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1], double tmpZ[MAX_LAYERS][MAX_NODES], double *, double *, double *, double *, double *, size_t, size_t,
-                               char);
-int estimate_layer_temperature(layer_data_struct *,
-                               double tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1], double tmpZ[MAX_LAYERS][MAX_NODES], double *, double *, size_t,
-                               size_t);
+void estimate_frost_temperature_and_depth(double ***, double **, double *,
+                                          double *, double *, double *,
+                                          double, size_t, size_t);
+int estimate_layer_ice_content(layer_data_struct *, double ***, double **,
+                               double *, double *, double *, double *, double *,
+                               size_t, size_t, char);
+int estimate_layer_temperature(layer_data_struct *, double ***, double **,
+                               double *, double *, size_t, size_t);
 int estimate_layer_temperature_quick_flux(layer_data_struct *, double *, double,
                                           double, double, double);
 int estimate_layer_ice_content_quick_flux(layer_data_struct *, double *,
@@ -164,6 +164,8 @@ void fda_heat_eqn(double *, double *, int, int, ...);
 void fdjac3(double *, double *, double *, double *, double *, void (*vecfunc)(
                 double *, double *, int, int, ...), int);
 void find_0_degree_fronts(energy_bal_struct *, double *, double *, int);
+void free_2d_double(size_t *shape, double **array);
+void free_3d_double(size_t *shape, double ***array);
 double func_atmos_energy_bal(double, va_list);
 double func_atmos_moist_bal(double, va_list);
 double func_canopy_energy_bal(double, va_list);
@@ -199,6 +201,8 @@ void latsens(double, double, double, double, double, double, double, double,
              double *, double *, double);
 double linear_interp(double, double, double, double, double);
 double lkdrag(double, double, double, double, double);
+void malloc_2d_double(size_t *shape, double ***array);
+void malloc_3d_double(size_t *shape, double ****array);
 void MassRelease(double *, double *, double *, double *);
 double maximum_unfrozen_water(double, double, double, double);
 double new_snow_density(double);

--- a/vic/vic_run/src/alloc_and_free.c
+++ b/vic/vic_run/src/alloc_and_free.c
@@ -1,0 +1,112 @@
+/******************************************************************************
+ * @section DESCRIPTION
+ *
+ * This subroutine redistributes soil properties based on the thermal solutions
+ * found for the current time step.
+ *
+ * @section LICENSE
+ *
+ * The Variable Infiltration Capacity (VIC) macroscale hydrological model
+ * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * and Environmental Engineering, University of Washington.
+ *
+ * The VIC model is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *****************************************************************************/
+
+#include <vic_run.h>
+
+/******************************************************************************
+ * @brief    This subroutine allocates memory for a 2-dimensional double array
+ *****************************************************************************/
+void
+malloc_2d_double(size_t   *shape,
+                 double ***array)
+{
+    size_t i;
+
+    *array = malloc(shape[0] * sizeof(**array));
+    if (*array == NULL) {
+        log_err("Memory allocation error in malloc_2d_double().");
+    }
+    for (i = 0; i < shape[0]; i++) {
+        *(array[i]) = malloc(shape[1] * sizeof(*(*(array[i]))));
+        if (*(array[i]) == NULL) {
+            log_err("Memory allocation error in malloc_2d_double().");
+        }
+    }
+}
+
+/******************************************************************************
+ * @brief    This subroutine allocates memory for a 3-dimensional double array
+ *****************************************************************************/
+void
+malloc_3d_double(size_t    *shape,
+                 double ****array)
+{
+    size_t i;
+    size_t j;
+
+    *array = malloc(shape[0] * sizeof(**array));
+    if (*array == NULL) {
+        log_err("Memory allocation error in malloc_3d_double().");
+    }
+
+    for (i = 0; i < shape[0]; i++) {
+        *(array[i]) = malloc(shape[1] * sizeof(*(*(array[i]))));
+        if (*(array[i]) == NULL) {
+            log_err("Memory allocation error in malloc_3d_double().");
+        }
+        for (j = 0; j < shape[1]; j++) {
+            *(array[i][j]) = malloc(shape[2] * sizeof(*(*(array[i][j]))));
+            if (*(array[i][j]) == NULL) {
+                log_err("Memory allocation error in malloc_3d_double().");
+            }
+        }
+    }
+}
+
+/******************************************************************************
+ * @brief    This subroutine frees memory for a 2-dimensional double array
+ *****************************************************************************/
+void
+free_2d_double(size_t  *shape,
+               double **array)
+{
+    size_t i;
+
+    for (i = 0; i < shape[0]; i++) {
+        free(array[i]);
+    }
+    free(array);
+}
+
+/******************************************************************************
+ * @brief    This subroutine frees memory for a 3-dimensional double array
+ *****************************************************************************/
+void
+free_3d_double(size_t   *shape,
+               double ***array)
+{
+    size_t i;
+    size_t j;
+
+    for (i = 0; i < shape[0]; i++) {
+        for (j = 0; j < shape[1]; j++) {
+            free(array[i][j]);
+        }
+        free(array[i]);
+    }
+    free(array);
+}

--- a/vic/vic_run/src/alloc_and_free.c
+++ b/vic/vic_run/src/alloc_and_free.c
@@ -36,13 +36,13 @@ malloc_2d_double(size_t   *shape,
 {
     size_t i;
 
-    *array = malloc(shape[0] * sizeof(**array));
+    *array = malloc(shape[0] * sizeof(*(*array)));
     if (*array == NULL) {
         log_err("Memory allocation error in malloc_2d_double().");
     }
     for (i = 0; i < shape[0]; i++) {
-        *(array[i]) = malloc(shape[1] * sizeof(*(*(array[i]))));
-        if (*(array[i]) == NULL) {
+        (*array)[i] = malloc(shape[1] * sizeof(*((*array)[i])));
+        if ((*array)[i] == NULL) {
             log_err("Memory allocation error in malloc_2d_double().");
         }
     }
@@ -58,19 +58,19 @@ malloc_3d_double(size_t    *shape,
     size_t i;
     size_t j;
 
-    *array = malloc(shape[0] * sizeof(**array));
+    *array = malloc(shape[0] * sizeof(*(*array)));
     if (*array == NULL) {
         log_err("Memory allocation error in malloc_3d_double().");
     }
 
     for (i = 0; i < shape[0]; i++) {
-        *(array[i]) = malloc(shape[1] * sizeof(*(*(array[i]))));
-        if (*(array[i]) == NULL) {
+        (*array)[i] = malloc(shape[1] * sizeof(*((*array)[i])));
+        if ((*array)[i] == NULL) {
             log_err("Memory allocation error in malloc_3d_double().");
         }
         for (j = 0; j < shape[1]; j++) {
-            *(array[i][j]) = malloc(shape[2] * sizeof(*(*(array[i][j]))));
-            if (*(array[i][j]) == NULL) {
+            (*array)[i][j] = malloc(shape[2] * sizeof(*((*array)[i][j])));
+            if ((*array)[i][j] == NULL) {
                 log_err("Memory allocation error in malloc_3d_double().");
             }
         }

--- a/vic/vic_run/src/frozen_soil.c
+++ b/vic/vic_run/src/frozen_soil.c
@@ -42,8 +42,10 @@ calc_layer_average_thermal_props(energy_bal_struct *energy,
 
     size_t               i;
     int                  ErrorFlag;
+    // sizes of tmpTshape and tmpZshape are hardcoded for convenience
     size_t               tmpTshape[] = {
-        MAX_LAYERS, MAX_NODES, MAX_FROST_AREAS + 1
+        MAX_LAYERS, MAX_NODES,
+        MAX_FROST_AREAS + 1
     };
     size_t               tmpZshape[] = {
         MAX_LAYERS, MAX_NODES

--- a/vic/vic_run/src/frozen_soil.c
+++ b/vic/vic_run/src/frozen_soil.c
@@ -42,8 +42,18 @@ calc_layer_average_thermal_props(energy_bal_struct *energy,
 
     size_t               i;
     int                  ErrorFlag;
-    double               tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1];
-    double               tmpZ[MAX_LAYERS][MAX_NODES];
+    size_t               tmpTshape[] = {
+        MAX_LAYERS, MAX_NODES, MAX_FROST_AREAS + 1
+    };
+    size_t               tmpZshape[] = {
+        MAX_LAYERS, MAX_NODES
+    };
+    double            ***tmpT;
+    double             **tmpZ;
+
+    // allocate memory for tmpT and tmpZ
+    malloc_3d_double(tmpTshape, &tmpT);
+    malloc_2d_double(tmpZshape, &tmpZ);
 
     if (options.FROZEN_SOIL && soil_con->FS_ACTIVE) {
         find_0_degree_fronts(energy, soil_con->Zsum_node, T, Nnodes);
@@ -122,6 +132,10 @@ calc_layer_average_thermal_props(energy_bal_struct *energy,
             return (ERROR);
         }
     }
+
+    // free memory for tmpT and tmpZ
+    free_3d_double(tmpTshape, tmpT);
+    free_2d_double(tmpZshape, tmpZ);
 
     return (0);
 }

--- a/vic/vic_run/src/soil_conduction.c
+++ b/vic/vic_run/src/soil_conduction.c
@@ -321,15 +321,15 @@ distribute_node_moisture_properties(double *moist_node,
 *           soil thermal node temperatures.
 ******************************************************************************/
 void
-estimate_frost_temperature_and_depth(double             tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1],
-                                     double             tmpZ[MAX_LAYERS][MAX_NODES],
-                                     double            *Zsum_node,
-                                     double            *T,
-                                     double            *depth,
-                                     double            *frost_fract,
-                                     double             frost_slope,
-                                     size_t             Nnodes,
-                                     size_t             Nlayers)
+estimate_frost_temperature_and_depth(double ***tmpT,
+                                     double  **tmpZ,
+                                     double   *Zsum_node,
+                                     double   *T,
+                                     double   *depth,
+                                     double   *frost_fract,
+                                     double    frost_slope,
+                                     size_t    Nnodes,
+                                     size_t    Nlayers)
 {
     extern option_struct options;
 
@@ -430,8 +430,8 @@ estimate_frost_temperature_and_depth(double             tmpT[MAX_LAYERS][MAX_NOD
 ******************************************************************************/
 int
 estimate_layer_temperature(layer_data_struct *layer,
-                           double             tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1],
-                           double             tmpZ[MAX_LAYERS][MAX_NODES],
+                           double          ***tmpT,
+                           double           **tmpZ,
                            double            *Zsum_node,
                            double            *depth,
                            size_t             Nnodes,
@@ -492,8 +492,8 @@ estimate_layer_temperature(layer_data_struct *layer,
 ******************************************************************************/
 int
 estimate_layer_ice_content(layer_data_struct *layer,
-                           double             tmpT[MAX_LAYERS][MAX_NODES][MAX_FROST_AREAS + 1],
-                           double             tmpZ[MAX_LAYERS][MAX_NODES],
+                           double          ***tmpT,
+                           double           **tmpZ,
                            double            *Zsum_node,
                            double            *depth,
                            double            *max_moist,


### PR DESCRIPTION
@yixinmao and @jhamman can you review this - seems like a lot of work for a style change. I'm fine if we don't use this.

@yixinmao - can you run my branch with your test cases to make sure there is no bug in how I allocate the memory?
