### PR TITLE
Fix timestep issue cesm driver

### DIFF
--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -140,7 +140,7 @@ vic_cesm_run(vic_clock *vclock)
 
     // advance the clock
     advance_time();
-    assert_time_insync(vlock, &dmy_current);
+    assert_time_insync(vclock, &dmy_current);
 
     // if save:
     if (vclock->state_flag) {

--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -138,6 +138,10 @@ vic_cesm_run(vic_clock *vclock)
     // Write history files
     vic_write_output(&dmy_current);
 
+    // advance the clock
+    advance_time();
+    assert_time_insync(vlock, &dmy_current);
+
     // if save:
     if (vclock->state_flag) {
         // write state file
@@ -147,10 +151,6 @@ vic_cesm_run(vic_clock *vclock)
 
     // reset x2l fields
     initialize_x2l_data();
-
-    // advance the clock
-    advance_time();
-    assert_time_insync(vclock, &dmy_current);
 
     // stop vic run timer
     timer_stop(&(global_timers[TIMER_VIC_RUN]));


### PR DESCRIPTION
This PR implements a fix to advance the timestep in the CESM driver for writing a statefile before entering vic_store, in accordance with how we've implemented this in the image driver. 